### PR TITLE
fixed syntax for enabling plugins. Added removeTitle, removeXMLNS, re…

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,12 @@
 var svg = require('svgo');
 
 var svgo = new svg({
-  plugins: ['removeDoctype', 'removeComments'],
+    plugins: [
+    {removeTitle: true},
+    {removeXMLNS: true},
+    {removeStyleElement: true},
+    {removeScriptElement: true}
+  ]
 });
 
 module.exports = function (content) {


### PR DESCRIPTION
fixed syntax for enabling plugins, previous syntax didn't correctly enable / disable plugins in svgo.

added and correctly enabled the following plugins

- `removeTitle` (useless for an inline SVG)
- `removeXMLNS` (same)
- `removeStyleElement`  (to avoid situations where an SVG with <style> tag produces an error / warning when used as template in Vue.js)
- `removeScriptElement` (same reason)

I also removed `removeDoctype` and `removeComments` which were enabled by default