### PR TITLE
Add svgo options

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,15 @@ yarn add --dev vue-template-compiler vue-svg-loader
 {
   test: /\.svg$/,
   loader: 'vue-svg-loader', // `vue-svg` for webpack 1.x
+  options: {
+    // optional [svgo](https://github.com/svg/svgo) options
+    svgo: {
+      plugins: [
+        {removeDoctype: true},
+        {removeComments: true}
+      ]
+    }
+  }
 }
 ```
 

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ var loaderUtils = require('loader-utils');
 var compiler = require('vue-template-compiler');
 
 module.exports = function (content) {
-  var options = loaderUtils.getOptions(this);
+  var options = loaderUtils.getOptions(this) || {};
   var svgo = new svg({
     plugins: options.svgo || ['removeDoctype', 'removeComments'],
   });

--- a/index.js
+++ b/index.js
@@ -1,11 +1,13 @@
 var svg = require('svgo');
+var loaderUtils = require('loader-utils');
 var compiler = require('vue-template-compiler');
 
-var svgo = new svg({
-  plugins: ['removeDoctype', 'removeComments'],
-});
-
 module.exports = function (content) {
+  var options = loaderUtils.getOptions(this);
+  var svgo = new svg({
+    plugins: options.svgo || ['removeDoctype', 'removeComments'],
+  });
+
   this.cacheable && this.cacheable(true);
   this.addDependency(this.resourcePath);
 

--- a/index.js
+++ b/index.js
@@ -3,10 +3,11 @@ var loaderUtils = require('loader-utils');
 var compiler = require('vue-template-compiler');
 
 module.exports = function (content) {
-  var options = loaderUtils.getOptions(this) || {
+  var options = loaderUtils.getOptions(this) || {};
+  var svgoOptions = options.svgo || {
     plugins: [{removeDoctype: true}, {removeComments: true}],
   };
-  var svgo = new svg(options);
+  var svgo = new svg(svgoOptions);
 
   this.cacheable && this.cacheable(true);
   this.addDependency(this.resourcePath);

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ var compiler = require('vue-template-compiler');
 module.exports = function (content) {
   var options = loaderUtils.getOptions(this) || {};
   var svgo = new svg({
-    plugins: options.svgo || ['removeDoctype', 'removeComments'],
+    plugins: options.svgo || [{removeDoctype: true}, {removeComments: true}],
   });
 
   this.cacheable && this.cacheable(true);

--- a/index.js
+++ b/index.js
@@ -3,10 +3,10 @@ var loaderUtils = require('loader-utils');
 var compiler = require('vue-template-compiler');
 
 module.exports = function (content) {
-  var options = loaderUtils.getOptions(this) || {};
-  var svgo = new svg({
-    plugins: options.svgo || [{removeDoctype: true}, {removeComments: true}],
-  });
+  var options = loaderUtils.getOptions(this) || {
+    plugins: [{removeDoctype: true}, {removeComments: true}],
+  };
+  var svgo = new svg(options);
 
   this.cacheable && this.cacheable(true);
   this.addDependency(this.resourcePath);

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "vue-template-compiler": "^2.0.0"
   },
   "dependencies": {
+    "loader-utils": "^1.1.0",
     "svgo": "^0.7.2"
   }
 }


### PR DESCRIPTION
This allows the loader config to parse along different svgo options than the currently hard-coded defaults (plugins specifically).

Reading both [this issue](https://github.com/visualfanatic/vue-svg-loader/issues/5) and to some degree [this pull request](https://github.com/visualfanatic/vue-svg-loader/pull/3) this feature would essentially address both by making svgo fully customizable. Very similar to the way both [svgo-loader](https://github.com/rpominov/svgo-loader) and [image-webpack-loader](https://github.com/tcoopman/image-webpack-loader) implement svgo the loader config can be given an (optional) svgo property with plugins:
```js
{
  test: /\.svg$/,
  loader: 'vue-svg-loader', // `vue-svg` for webpack 1.x
  options: {
    // optional svgo options
    svgo: {
      plugins: [
        {removeDoctype: true},
        {removeComments: true},
        {cleanupIDs: false}
      ]
    }
  }
}
```