### PR TITLE
Upgrade to SVGO 1.0.0+

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,6 @@
   },
   "dependencies": {
     "loader-utils": "^1.1.0",
-    "svgo": "^0.7.2"
+    "svgo": "^1.0.0"
   }
 }


### PR DESCRIPTION
In addition to upgrading to the latest version of SVGO, this PR also switches to the new Promise-based method of calling `svgo.optimize` and also provides the new `info` object when calling `optimize`, which allows IDs to be prefixed using the new `prefixIds` plugin.

Here's an example of the `info` object in use: https://github.com/svg/svgo/blob/a6d2c88f9ca128e145d06b05bd9b87c1985b0a15/examples/test.js#L15-L28