### PR TITLE
Add option to disable svgo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
-node_modules
+node_modules/
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ yarn add --dev vue-svg-loader
   test: /\.svg$/,
   loader: 'vue-svg-loader', // `vue-svg` for webpack 1.x
   options: {
+    // optional
+    useSvgo: true, // default: true
+
     // optional [svgo](https://github.com/svg/svgo) options
     svgo: {
       plugins: [


### PR DESCRIPTION
As per #31, this PR adds an option to disable svgo.

### Usage
```javascript
{
  test: /\.svg$/,
  loader: 'vue-svg-loader',
  options: {
    useSvgo: true, // default: true
  }
}
```

### Explanation
This works by adding the `getSvg` method that replaces the current `svg.optimize`. If `useSvgo` is undefined or set to `true`, it will operate as before.

If `useSvgo` is set to `false`, it will use `fs.readFile` in order to read the SVG in and then simply use that.

/cc @visualfanatic 