### PR TITLE
Remove absolute paths

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,13 +15,12 @@ module.exports = function (content) {
   let component;
 
   svg
-    .optimize(content, { path })
+    .optimize(content)
     .then((result) => {
       const compiled = compiler.compile(result.data, { preserveWhitespace: false });
 
       component = transpile(`var render = function () {${compiled.render}};`);
-      component += `var toString = function () {return ${JSON.stringify(path)}};`;
-      component += `module.exports = { render, toString };`;
+      component += `module.exports = { render };`;
 
       cb(null, component);
     })

--- a/index.js
+++ b/index.js
@@ -15,13 +15,13 @@ module.exports = function (content) {
   let component;
 
   svg
-    .optimize(content, { path: path })
+    .optimize(content, { path })
     .then((result) => {
       const compiled = compiler.compile(result.data, { preserveWhitespace: false });
 
       component = transpile(`var render = function () {${compiled.render}};`);
       component += `var toString = function () {return ${JSON.stringify(path)}};`;
-      component += `module.exports = { render: render, toString: toString };`;
+      component += `module.exports = { render, toString };`;
 
       cb(null, component);
     })


### PR DESCRIPTION
Resolves #30.

For some reason, there was a `toString()` method included in the component that returned an absolute path to the original SVG. This PR simply removes that method from both the definition syntax and from the module.exports functionality. If a path relative to the webpack build can be used instead, then perhaps it should, but I can't see a reason why it would be after the SVG data has been imported.

It doesn't appear to be. a required part of the component syntax, and everything seems to work fine in both Vue 1 & Vue 2 after testing.