### PR TITLE
docs(readme): add remark about nuxt-svg-loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ module.exports = {
 };
 ```
 
+For Nuxt 2, there is also a wrapper called [nuxt-svg-loader](https://github.com/Developmint/nuxt-svg-loader)
+
+
 ## Example usage
 ``` vue
 <template>


### PR DESCRIPTION
As I've release [nuxt-svg-loader](https://github.com/Developmint/nuxt-svg-loader) I thought it'd be nice for the users to mention it here.

If you don't want the mention, simply close this PR :relaxed: It's up to you!