### PR TITLE
Make logo visible from npmjs.org.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<p align="center"><img src="docs/.vuepress/public/logo.svg" width="40%"></p>
+<p align="center"><img src="docs/.vuepress/public/logo.svg?sanitize=true" width="40%"></p>
 <h1 align="center">vue-svg-loader</h1>
 <p align="center">webpack loader that lets you use SVG files as Vue components</p>
 <p align="center">


### PR DESCRIPTION
Added a `sanitize=true` attribute to the readme logo URI querystring.
This allows the readme logo to load on npmjs.org.

Probably more of an issue with npmjs seeing as GitHub automagically applies this querystring to your logo when rendering the readme. Nevertheless, this will make your logo render properly on the npm website. 😄

# Before
[![Screenshot from Gyazo](https://gyazo.com/910d7c1d123fb1a9250a80ba3e434efe/raw)](https://gyazo.com/910d7c1d123fb1a9250a80ba3e434efe)

# After
[![Screenshot from Gyazo](https://gyazo.com/d4605ab7826ef08bbf74d698af1a3d9d/raw)](https://gyazo.com/d4605ab7826ef08bbf74d698af1a3d9d)