### PR TITLE
issue-80: Added Vue config including babel-loader in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,31 @@ module.exports = {
 };
 ```
 
+NOTE: When you want to support legacy browsers, you have to pass the generated JS also trough babel, as es6 syntax is used:
+
+``` js
+module.exports = {
+  chainWebpack: (config) => {
+    const svgRule = config.module.rule("svg")
+
+    svgRule.uses.clear()
+    svgRule
+      .use("babel-loader")
+      .loader("babel-loader")
+      .end()
+      .use("vue-svg-loader")
+      .loader("vue-svg-loader")
+      .options({
+        svgo: {
+          plugins: [{ removeDoctype: true }, { removeComments: true }, { removeViewBox: false }],
+          removeViewBox: false,
+        },
+      })
+      .end()
+  },
+};
+```
+
 ### Nuxt.js (1.x / 2.x)
 ``` js
 module.exports = {


### PR DESCRIPTION
This is required to support legacy browsers that don's support es6 syntax. This addreses issue #80.

I think [youcanping's updated version of the vue config](https://github.com/visualfanatic/vue-svg-loader/issues/80#issuecomment-501942032) should be very prominent in the docs, so I added this as variante to the README.