### PR TITLE
Update Typescript type in faq

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -349,7 +349,8 @@ To fix that you need to provide a type definition which is needed by TypeScript 
 
 ``` ts
 declare module '*.svg' {
-  const content: any;
+  import Vue, {VueConstructor} from 'vue';
+  const content: VueConstructor<Vue>;
   export default content;
 }
 ```


### PR DESCRIPTION
If you have strict type checking and don't allow `any`, you should specify your SVG's as a `VueConstructor` of type `Vue`.