### PR TITLE
Add 'babel-loader' in basic configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ module.exports = {
       {
         test: /\.svg$/,
         use: [
+          'babel-loader', // 'babel-loader' is optional to help it work in old browsers
           'vue-loader',
           'vue-svg-loader',
         ],
@@ -39,6 +40,9 @@ module.exports = {
     svgRule.uses.clear();
 
     svgRule
+      .use('babel-loader') // 'babel-loader' is optional to help it work in old browsers
+      .loader('babel-loader')
+      .end()
       .use('vue-loader')
       .loader('vue-loader') // or `vue-loader-v16` if you are using a preview support of Vue 3 in Vue CLI
       .end()
@@ -60,6 +64,7 @@ module.exports = {
       config.module.rules.push({
         test: /\.svg$/,
         use: [
+          'babel-loader', // 'babel-loader' is optional to help it work in old browsers
           'vue-loader',
           'vue-svg-loader',
         ],


### PR DESCRIPTION
Hello. `vue-svg-loader` is very nice.

How about adding `babel-loader` in basic configuration example? Because without it, an error happens in IE11 and I spent a lot of time to fix it. I finally found the solution on your `vue-svg-loader` npm page. I added extra comments just in case but it seems too much at the same time. If it does, let me remove it. I want to hear your opinions. Thanks.