### PR TITLE
Add slots to SVGs

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,5 +17,9 @@ module.exports = function vueSvgLoader(svg) {
     svg = svg.replace('<svg', '<svg v-on="$listeners"');
   }
 
+  if (semverMajor(version) === 3) {
+    svg = svg.replace('</svg>', '<slot></slot></svg>');
+  }
+
   return `<template>${svg}</template>`;
 };


### PR DESCRIPTION
While attempting to upgrade a Vue 2 app to Vue 3, I found that all of my
SVGs needed to have a <slot> to be able to render child nodes.