### PR TITLE
Update the TypeScript example for Vue.js 3.

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -349,8 +349,9 @@ To fix that you need to provide a type definition which is needed by TypeScript 
 
 ``` ts
 declare module '*.svg' {
-  import Vue, {VueConstructor} from 'vue';
-  const content: VueConstructor<Vue>;
+  import type { SVGAttributes, DefineComponent } from 'vue';
+
+  const content: DefineComponent<SVGAttributes>;
   export default content;
 }
 ```


### PR DESCRIPTION
It not only makes it work on Vue.js 3, but also makes it recognize the element as `<svg>`.